### PR TITLE
fix: resetting the prompt fixes the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ require("telescope").extensions.arecibo.websearch()
 
 ### Highlight groups:
 
-- Result Index :       `TelescopeAreciboNumber`
-- Result URL   :       `TelescopeAreciboUrl`
-- Result Mode Prompt : `TelescopePromptPrefix`
-- Query Mode Prompt  : `TelescopeAreciboPrompt`
-
-
+- Result Index :         `TelescopeAreciboNumber`
+- Result URL   :         `TelescopeAreciboUrl`
+- Result Mode Prompt :   `TelescopePromptPrefix`
+- Query Mode Prompt  :   `TelescopeAreciboPrompt`
+- Progress Mode Prompt : `TelescopeAreciboPromptProgress`

--- a/lua/telescope/_extensions/arecibo.lua
+++ b/lua/telescope/_extensions/arecibo.lua
@@ -101,6 +101,7 @@ end
 local function in_progress_animation()
   state.current_frame = state.current_frame >= #spinner_anim_frames and 1 or state.current_frame + 1
   state.picker:change_prompt_prefix(spinner_anim_frames[state.current_frame], 'TelescopeAreciboPromptProgress')
+  state.picker:reset_prompt()
 end
 
 local function create_previewer()


### PR DESCRIPTION
The progress animation prompt was being added below the old prompt for each frame. This would raise the below error in the logs which is coming from [here](https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/pickers.lua#L389):
```
[DEBUG Wed May 12 10:15:09 2021] ...pack/packer/opt/telescope.nvim/lua/telescope/pickers.lua:389: ON_LINES: Bad range 1 2 
```
Resetting the prompt fixes this issue.


https://user-images.githubusercontent.com/67177269/117955955-342e7d80-b336-11eb-83a7-f585ca5a70e2.mov


https://user-images.githubusercontent.com/67177269/117955966-37296e00-b336-11eb-9200-aa5377925513.mov

